### PR TITLE
[2784][FIX] hr_holidays_compute_days

### DIFF
--- a/hr_holidays_compute_days/models/hr_holidays.py
+++ b/hr_holidays_compute_days/models/hr_holidays.py
@@ -156,8 +156,9 @@ class HrHolidays(models.Model):
                 include_rest_days=not self.holiday_status_id.exclude_rest_days,
                 compute_full_days=self.holiday_status_id.compute_full_days,
             )
-            days = employee.get_work_days_count(
-                from_datetime=date_from, to_datetime=date_to,
-            )
-            if days:
-                self.number_of_days_temp = days
+            if employee:
+                days = employee.get_work_days_count(
+                    from_datetime=date_from, to_datetime=date_to,
+                )
+                if days:
+                    self.number_of_days_temp = days


### PR DESCRIPTION
[2784](https://www.quartile.co/web?debug=1#id=2784&action=771&model=project.task&view_type=form&menu_id=505)

Before this fix, get_work_days_count() would throw a server error if no employee has been selected. This behavior may usually not be noticeable when there is an employee record linked to the user. However you would get an error the moment you try to create a new leave/allocation record otherwise (i.e. you are an non-employee admin).